### PR TITLE
fix package name in shield

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,5 +1,5 @@
 # @thefakeorg/react
 
-[![Stable release](https://img.shields.io/npm/v/@thefakeorg/utils.svg)](https://npm.im/@thefakeorg/utils)
+[![Stable release](https://img.shields.io/npm/v/@thefakeorg/react.svg)](https://npm.im/@thefakeorg/react)
 
 Official React package for @thefakeorg


### PR DESCRIPTION
Noticed while exploring the repo that the shield link refers to `utils` where it seems it should be `react`.